### PR TITLE
add license ids enums from hydroshare for zenodo schema

### DIFF
--- a/dspback/schemas/zenodo/schema.json
+++ b/dspback/schemas/zenodo/schema.json
@@ -175,7 +175,17 @@
     "license": {
       "title": "License",
       "type": "string",
-      "description": "License for embargoed/open access content."
+      "description": "License for embargoed/open access content.",
+      "enum": [
+        "CC-BY-4.0",
+        "CC-BY-SA-4.0",
+        "CC-BY-ND-4.0",
+        "CC-BY-NC-SA-4.0",
+        "CC-BY-NC-4.0",
+        "CC-BY-NC-ND-4.0",
+        "other-open",
+        "other-at"
+      ]
     },
     "notes": {
       "title": "Additional notes",


### PR DESCRIPTION
If we want labels for these, there is a possible workaround with oneOf

https://github.com/eclipsesource/jsonforms/pull/1591

I pulled the license ids from
https://spdx.org/licenses/