### PR TITLE
Switch oneOf to anyOf

### DIFF
--- a/dspback/schemas/earthchem/schema.json
+++ b/dspback/schemas/earthchem/schema.json
@@ -39,7 +39,7 @@
       "items": {
         "title": "Related Information",
         "options": { "flat": true, "dropdown": true },
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "title": "Publication DOI",
@@ -662,7 +662,7 @@
       "title": "License",
       "type": "object",
       "options": { "dropdown": true },
-      "oneOf": [
+      "anyOf": [
         {
           "title": "CC-BY-NC-SA-3.0",
           "properties": {

--- a/dspback/schemas/external/schema.json
+++ b/dspback/schemas/external/schema.json
@@ -165,7 +165,7 @@
     "spatialCoverage": {
       "title": "Spatial coverage",
       "description": "The place(s) that are the focus of the resource. The geospatial area that the resource describes, the spatial topic of a resource, the spatial applicability of a resource, or jurisdiction under with a resource is relevant.",
-      "oneOf": [
+      "anyOf": [
         {
           "title": "Point Coverage Metadata",
           "description": "Geographic coverage metadata for a resource or aggregation expressed as a point location",

--- a/dspback/schemas/hydroshare/schema.json
+++ b/dspback/schemas/hydroshare/schema.json
@@ -66,7 +66,7 @@
     "rights": {
       "title": "Rights",
       "description": "An object containing information about rights held in an over a resource",
-      "oneOf": [
+      "anyOf": [
         {
           "title": "Choose a License",
           "description": "An object containing information about rights held in an over a resource",
@@ -125,7 +125,7 @@
     "spatial_coverage": {
       "title": "Spatial coverage",
       "description": "An object containing information about the spatial topic of a resource, the spatial applicability of a resource, or jurisdiction under with a resource is relevant",
-      "oneOf": [
+      "anyOf": [
         {
           "title": "Point Coverage Metadata",
           "description": "A class used to represent geographic coverage metadata for a resource or aggregation expressed as a\npoint location",

--- a/dspback/schemas/zenodo/schema.json
+++ b/dspback/schemas/zenodo/schema.json
@@ -202,7 +202,7 @@
       "title": "License",
       "type": "string",
       "description": "License for embargoed/open access content.",
-      "oneOf": [
+      "anyOf": [
         { "const": "CC-BY-4.0", "title": "Creative Commons Attribution 4.0" },
         { "const": "CC-BY-SA-4.0", "title": "Creative Commons Attribution Share-Alike 4.0" },
         { "const": "CC-BY-NC-4.0", "title": "Creative Commons Attribution-NonCommercial 4.0" },


### PR DESCRIPTION
oneOf schemas fail to validate if the condition is satisfied by two or more subschemas. We don't need this conditionality in any of our use cases right now, so we'll switch to anyOf schemas.