### PR TITLE
update earthchem authors from creators to contributors+leadAuthor

### DIFF
--- a/dspback/pydantic_schemas.py
+++ b/dspback/pydantic_schemas.py
@@ -176,20 +176,23 @@ class HydroShareRecord(BaseRecord):
 
 
 class EarthChemRecord(BaseRecord):
-    class Creator(BaseModel):
+    class Contributor(BaseModel):
         givenName: str = None
         familyName: str = None
 
     title: str = None
-    creators: List[Creator] = []
+    contributors: List[Contributor] = []
+    leadAuthor: Contributor = None
 
     def to_submission(self, identifier) -> Submission:
         settings = get_settings()
         view_url = settings.earthchem_view_url
         view_url = view_url % identifier
+        authors = [f"{contributor.familyName}, {contributor.givenName}" for contributor in self.contributors]
+        authors.insert(0, f"{self.leadAuthor.familyName}, {self.leadAuthor.givenName}")
         return Submission(
             title=self.title,
-            authors=[f"{creator.familyName}, {creator.givenName}" for creator in self.creators],
+            authors=authors,
             repo_type=RepositoryType.EARTHCHEM,
             submitted=datetime.utcnow(),
             identifier=identifier,

--- a/tests/data/earthchem.json
+++ b/tests/data/earthchem.json
@@ -38,14 +38,16 @@
       }
     }
   ],
+  "leadAuthor": {
+    "familyName": "lead",
+    "givenName": "author"
+  },
   "contributors": [
     {
-      "familyName": "string",
+      "familyName": "second",
       "additionalName": "string",
-      "givenName": "string",
+      "givenName": "author",
       "email": "string",
-      "type": "leadAuthor",
-      "position": 0,
       "identifiers": [
         {
           "scheme": "string",

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -46,14 +46,14 @@ def test_external_to_submission(external):
     assert external_submission.url == external_record.url
 
 
-def test_eartchchem_to_submission(earthchem):
+def test_earthchem_to_submission(earthchem):
     earthchem_record = EarthChemRecord(**earthchem)
     earthchem_submission = earthchem_record.to_submission("947940")
 
     assert earthchem_submission.title == earthchem_record.title
-    assert earthchem_submission.authors == [
-        f"{creator.familyName}, {creator.givenName}" for creator in earthchem_record.creators
-    ]
+    authors = [f"{contributor.familyName}, {contributor.givenName}" for contributor in earthchem_record.contributors]
+    authors.insert(0, f"{earthchem_record.leadAuthor.familyName}, {earthchem_record.leadAuthor.givenName}")
+    assert earthchem_submission.authors == authors
     assert earthchem_submission.repo_type == RepositoryType.EARTHCHEM
     assert earthchem_submission.submitted <= datetime.utcnow()
     assert earthchem_submission.identifier == "947940"


### PR DESCRIPTION
Description from @Maurier 
>The endpoint that returns my submissions from our database is populating the authors field with creator data.
![image](https://user-images.githubusercontent.com/35820390/179005373-604db8b3-dd3c-48e0-bb2e-7e60cad821f7.png)
In this example for an EarthChem submission, it gives me back my user  as the author, no matter what I type in in the form as lead author. 
It should be populated with an array of lead author and all contributors