### PR TITLE
disable selenium tests workflow on Develop

### DIFF
--- a/.github/workflows/selenium_browser_qa.yml
+++ b/.github/workflows/selenium_browser_qa.yml
@@ -2,9 +2,12 @@ name: Selenium Browser QA Tests
 
 on:
   push:
-    branches: [develop]
+    # TODO: enable on develop push/PR once QA tests run reliably from GH workflow
+    branches: [disable-selenium]
+    # branches: [develop]
   pull_request:
-    branches: [develop]
+    branches: [disable-selenium]
+    # branches: [develop]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Right now our QA tests fail with a bunch of false negatives when run via GH Worklfow. Disabling them for now until I can get them to run reliably

Will run manually for now.