### PR TITLE
Update orcid regex pattern and make funding source optional

### DIFF
--- a/dspback/schemas/earthchem/schema.json
+++ b/dspback/schemas/earthchem/schema.json
@@ -492,8 +492,7 @@
     "additionalTypes",
     "community",
     "type",
-    "status",
-    "fundings"
+    "status"
   ],
   "definitions": {
     "Affiliation": {

--- a/dspback/schemas/earthchem/schema.json
+++ b/dspback/schemas/earthchem/schema.json
@@ -634,7 +634,7 @@
         "identifier": {
           "title": "ORCID",
           "type": "string",
-          "pattern": "(\\d{4}-){3}\\d{4}",
+          "pattern": "\\b\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]\\b",
           "options": {
             "placeholder": "e.g. '0000-0001-2345-6789'"
           },

--- a/dspback/schemas/external/schema.json
+++ b/dspback/schemas/external/schema.json
@@ -455,7 +455,7 @@
           "title": "ORCID",
           "description": "ORCID identifier for creator.",
           "type": "string",
-          "pattern": "(\\d{4}-){3}\\d{4}",
+          "pattern": "\\b\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]\\b",
           "options": {
             "placeholder": "e.g. '0000-0001-2345-6789'"
           },
@@ -496,7 +496,7 @@
           "title": "ORCID",
           "description": "ORCID identifier for contributor.",
           "type": "string",
-          "pattern": "(\\d{4}-){3}\\d{4}",
+          "pattern": "\\b\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]\\b",
           "options": {
             "placeholder": "e.g. '0000-0001-2345-6789'"
           },

--- a/dspback/schemas/zenodo/schema.json
+++ b/dspback/schemas/zenodo/schema.json
@@ -64,7 +64,7 @@
             "title": "ORCID",
             "description": "ORCID identifier for contributor.",
             "type": "string",
-            "pattern": "(\\d{4}-){3}\\d{4}",
+            "pattern": "\\b\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]\\b",
             "options": {
               "placeholder": "e.g. '0000-0001-2345-6789'"
             },
@@ -133,7 +133,7 @@
             "title": "ORCID",
             "description": "ORCID identifier for creator.",
             "type": "string",
-            "pattern": "(\\d{4}-){3}\\d{4}",
+            "pattern": "\\b\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]\\b",
             "options": {
               "placeholder": "e.g. '0000-0001-2345-6789'"
             },


### PR DESCRIPTION
Context: https://support.orcid.org/hc/en-us/articles/360053289173-Why-does-my-ORCID-iD-have-an-X-

`\b\d{4}-\d{4}-\d{4}-\d{3}[0-9X]\b`
This regular expression matches a string that starts and ends with a word boundary \b, and contains four groups of four digits separated by hyphens. The last group can either be a digit from 0-9 or the letter "X". This pattern matches the standard format for ORCID iDs.

Here are some examples of strings that would match this regular expression:

0000-0002-1825-0097
0000-0002-1694-233X
0000-1111-2222-3333

And here are some examples of strings that would not match:

123-45-6789 (not enough groups)
0000-0002-1825-009Z (last group must be a digit or "X")
0000000218250097 (missing hyphens)

------------
Also makes the 'Funding Source' field optional.