### PR TITLE
add pre change document for submission deletion

### DIFF
--- a/management/change_streams_pre_and_post.py
+++ b/management/change_streams_pre_and_post.py
@@ -14,6 +14,7 @@ async def main():
     # discovery records when a submission is deleted
     await db[get_settings().mongo_database].command(
         ({'collMod': Submission.get_collection_name(), "changeStreamPreAndPostImages": {'enabled': True}}))
+    db.close()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/management/change_streams_pre_and_post.py
+++ b/management/change_streams_pre_and_post.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from beanie import init_beanie
+from motor.motor_asyncio import AsyncIOMotorClient
+from dspback.config import get_settings
+from dspback.pydantic_schemas import Submission
+
+
+async def main():
+    db = AsyncIOMotorClient(get_settings().mongo_url)
+    await init_beanie(database=db[get_settings().mongo_database], document_models=[Submission])
+    # https://www.mongodb.com/docs/manual/reference/command/collMod/#change-streams-with-document-pre--and-post-images
+    # This enables us to get the record id of a deleted submission within a trigger.  We need this for removing
+    # discovery records when a submission is deleted
+    await db[get_settings().mongo_database].command(
+        ({'collMod': Submission.get_collection_name(), "changeStreamPreAndPostImages": {'enabled': True}}))
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ typing_extensions==4.3.0
 urllib3==1.26.9
 uvicorn==0.17.6
 geojson==3.0.0
-motor==3.1.1
+motor==3.1.2
 beanie==1.17.0
 aiohttp==3.8.3
 rocketry==2.5.1


### PR DESCRIPTION
In order for the discovery trigger that is listening to submission changes to delete a discovery record after a submission is deleted the changeStreamPreAndPostImages option must be enabled on the Submission collection. https://www.mongodb.com/docs/manual/reference/command/collMod/#change-streams-with-document-pre--and-post-images

Before this update when submissions were deleted the discovery collection was not updated because the trigger could not access the record id.  This is an edge case that was somehow missed in our tests.