### PR TITLE
Return 401 in case of unauthorized repository

### DIFF
--- a/dspback/dependencies.py
+++ b/dspback/dependencies.py
@@ -10,7 +10,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 from jose import JWTError, jwt
 from pydantic import BaseModel
 from starlette import status
-from starlette.status import HTTP_403_FORBIDDEN
+from starlette.status import HTTP_401_FORBIDDEN
 
 from dspback.config import Settings, get_settings, oauth
 from dspback.database.procedures import delete_repository_access_token
@@ -74,7 +74,7 @@ class OAuth2AuthorizationBearerToken(OAuth2):
 
         if not authorization:
             if self.auto_error:
-                raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Not authenticated")
+                raise HTTPException(status_code=HTTP_401_FORBIDDEN, detail="Not authenticated")
             else:
                 return None
         return param
@@ -189,13 +189,13 @@ async def get_current_repository_token(
 ) -> RepositoryToken:
     repository_token: RepositoryToken = user.repository_token(repository)
     if not repository_token:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"User has not authorized with {repository}")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"User has not authorized with {repository}")
     expiration_buffer: int = settings.access_token_expiration_buffer_seconds
     now = int(datetime.utcnow().timestamp())
 
     if now > repository_token.expires_at:
         await delete_repository_access_token(repository, user)
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"User token for {repository} has expired")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"User token for {repository} has expired")
     if now > repository_token.expires_at - expiration_buffer:
         if repository_token.refresh_token:
             client = getattr(oauth, repository)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -13,7 +13,7 @@ from tests import authorize_response, client_test
 async def test_submissions_not_logged_in(client_test):
     response = await client_test.get(url_for(client_test, "get_urls", repository="hydroshare"))
     assert response.json() == {"detail": "Not authenticated"}
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 async def test_login(client_test):
@@ -51,4 +51,4 @@ async def test_logout(client_test, authorize_response):
     logged_out_response = await client_test.get(
         url_for(client_test, "get_urls", repository="hydroshare"), follow_redirects=False
     )
-    assert logged_out_response.status_code == 403
+    assert logged_out_response.status_code == 401

--- a/tests/test_metadata_class.py
+++ b/tests/test_metadata_class.py
@@ -100,5 +100,5 @@ def test_create_hydroshare_record(user_cookie, hydroshare, authorize_response_hy
 
 async def test_unauthorized_hydroshare(client_test, user_cookie, hydroshare):
     response = await client_test.post(prefix + "/metadata/hydroshare?access_token=" + user_cookie, json=hydroshare)
-    assert response.status_code == 403
+    assert response.status_code == 401
     assert response.text == '{"detail":"User has not authorized with hydroshare"}'


### PR DESCRIPTION
We should be returning 401 error codes in case of unauthorized repositories. 403 is more general and repositories use it to indicate access control errors.