### PR TITLE
Ecl discovery patch

### DIFF
--- a/dspback/config/__init__.py
+++ b/dspback/config/__init__.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
     earthchem_file_delete_url: HttpUrl
     earthchem_file_read_url: HttpUrl
     earthchem_view_url: HttpUrl
+    earthchem_public_view_url: HttpUrl
     earthchem_health_url: HttpUrl
 
     mongo_username: str

--- a/dspback/pydantic_schemas.py
+++ b/dspback/pydantic_schemas.py
@@ -264,8 +264,7 @@ class EarthChemRecord(BaseRecord):
 
     def to_submission(self, identifier) -> Submission:
         settings = get_settings()
-        view_url = settings.earthchem_view_url
-        view_url = view_url % identifier
+        view_url = settings.earthchem_public_view_url % identifier
         authors = [contributor.name for contributor in self.contributors]
         authors.insert(0, self.leadAuthor.name)
         return Submission(

--- a/dspback/utils/jsonld/formatter.py
+++ b/dspback/utils/jsonld/formatter.py
@@ -60,4 +60,8 @@ def format_fields(json_ld):
         for author_role in [author_list['author'] for author_list in json_ld['author']['@list']]:
             json_ld["creator"] = {'@list': author_role}
 
+    if "@context" in json_ld:
+        if not isinstance(json_ld["@context"], str):
+            json_ld["@context"] = json_ld["@context"]["@vocab"]
+
     return json_ld

--- a/management/refresh_submission_url_earthchem.py
+++ b/management/refresh_submission_url_earthchem.py
@@ -1,0 +1,38 @@
+import asyncio
+from dspback.pydantic_schemas import RepositoryType
+
+import motor
+from beanie import init_beanie
+
+from dspback.config import get_settings
+from dspback.pydantic_schemas import Submission
+
+'''
+This python script updates the ECL submission urls.
+
+Example call:
+
+docker exec dspback python management/refresh_submission_url_earthchem.py
+'''
+
+async def initiaize_beanie():
+    db = motor.motor_asyncio.AsyncIOMotorClient(get_settings().mongo_url)
+    await init_beanie(
+        database=db[get_settings().mongo_database], document_models=[Submission]
+    )
+
+async def main():
+    await initiaize_beanie()
+
+    count = 0
+    for submission in await Submission.find(Submission.repo_type == RepositoryType.EARTHCHEM).to_list():
+        print(f"updating {submission.url}")
+        submission.url = get_settings().earthchem_public_view_url % submission.identifier
+        await submission.save()
+        print(f"to {submission.url}")
+        count = count + 1
+    print(f"total submission updated {count}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cryptography==36.0.2
 dnspython==2.2.1
 ecdsa==0.17.0
 email-validator==1.1.3
-fastapi==0.86.0
+fastapi==0.89.0
 fastapi-restful==0.4.3
 greenlet==1.1.2
 h11==0.12.0
@@ -51,7 +51,7 @@ rsa==4.8
 six==1.16.0
 sniffio==1.2.0
 soupsieve==2.3.1
-starlette==0.20.4
+starlette==0.22.0
 tomli==2.0.1
 typing_extensions==4.3.0
 urllib3==1.26.9

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -5,7 +5,9 @@ from pydantic import BaseModel
 
 from dspback.pydantic_schemas import RepositoryType, Submission
 from dspback.scheduler import retrieve_submission_json_ld
+from dspback.schemas.discovery import JSONLD
 from dspback.utils.jsonld.clusters import clusters
+from dspback.utils.jsonld.scraper import format_fields
 
 ids_and_cluster = [
     ("2012073", "Bedrock Cluster"),
@@ -135,3 +137,134 @@ async def test_external_jsonld():
     public_jsonld = await retrieve_submission_json_ld(submission.dict())
     assert len(public_jsonld["clusters"]) == 1
     assert public_jsonld["clusters"][0] == "Drylands Cluster"
+
+
+@pytest.mark.asyncio
+async def test_earthchem_jsonld():
+    metadata_json = {
+        "@context": {"@vocab": "https://schema.org/", "datacite": "http://purl.org/spar/datacite/"},
+        "@id": "https://doi.org/10.1594/IEDA/100243",
+        "@type": "Dataset",
+        "name": "Susquehanna Shale Hills Critical Zone Observatory Stream Water Chemistry (2010)",
+        "sameAs": "https://ecl.earthchem.org/view.php?id=523",
+        "isAccessibleForFree": True,
+        "citation": ["https://doi.org/10.2136/vzj2010.0133"],
+        "author": {
+            "@list": [
+                {
+                    "@type": "Role",
+                    "author": [
+                        {"@type": "Person", "name": "Susan L. Brantley", "givenName": "Susan", "familyName": "Brantley"}
+                    ],
+                    "roleName": "Lead Author",
+                },
+                {
+                    "@type": "Role",
+                    "author": [
+                        {
+                            "@type": "Person",
+                            "name": "Pamela L. Sullivan",
+                            "givenName": "Pamela",
+                            "familyName": "Sullivan",
+                        },
+                        {
+                            "@type": "Person",
+                            "name": "Danielle  Andrews",
+                            "givenName": "Danielle",
+                            "familyName": "Andrews",
+                        },
+                        {"@type": "Person", "name": "George  Holmes", "givenName": "George", "familyName": "Holmes"},
+                        {"@type": "Person", "name": "Molly  Holleran", "givenName": "Molly", "familyName": "Holleran"},
+                        {
+                            "@type": "Person",
+                            "name": "Jennifer Z. Williams",
+                            "givenName": "Jennifer",
+                            "familyName": "Williams",
+                        },
+                        {
+                            "@type": "Person",
+                            "name": "Elizabeth  Herndon",
+                            "givenName": "Elizabeth",
+                            "familyName": "Herndon",
+                        },
+                        {"@type": "Person", "name": "Maya  Bhatt", "givenName": "Maya", "familyName": "Bhatt"},
+                        {
+                            "@type": "Person",
+                            "name": "Ekaterina  Bazilevskaya",
+                            "givenName": "Ekaterina",
+                            "familyName": "Bazilevskaya",
+                        },
+                        {
+                            "@type": "Person",
+                            "name": "Tiffany  Yesavage",
+                            "givenName": "Tiffany",
+                            "familyName": "Yesavage",
+                        },
+                        {"@type": "Person", "name": "Evan  Thomas", "givenName": "Evan", "familyName": "Thomas"},
+                        {"@type": "Person", "name": "Chris J. Duffy", "givenName": "Chris", "familyName": "Duffy"},
+                    ],
+                    "roleName": "Coauthor",
+                },
+            ]
+        },
+        "description": "Stream water chemistry at Susquehanna Shale Hills Critical Zone Observatory in 2010. Weekly to monthly grab samples were collected at three locations along the first order Stream: at the Headwater (SH), Middle (SM) and adjacent to the Weir (SW). Daily stream water sample were also collected adjacent to the weir from using automatic samplers (2700 series, Teledyne Isco, Lincoln, NE) and were referenced as SW-ISCO. ",
+        "distribution": {
+            "datePublished": "2013-02-05 00:00:00",
+            "contentUrl": "https://ecl.earthchem.org/view.php?id=523",
+            "@type": "DataDownload",
+            "encodingFormat": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
+        "license": "https://spdx.org/licenses/CC-BY-SA-4.0",
+        "dateCreated": "2013-02-04",
+        "inLanguage": "English",
+        "keywords": [
+            "Susquehanna Shale Hills",
+            "Pennsylvania",
+            "Regional (Continents, Oceans)",
+            "Stream water",
+            "geochemistry",
+            "DOC",
+            "trace elements",
+            "major ions",
+        ],
+        "publisher": {
+            "contactPoint": {
+                "@type": "ContactPoint",
+                "name": "Information Desk",
+                "contactType": "Customer Service",
+                "email": "info@earthchem.org",
+                "url": "https://www.earthchem.org/contact/",
+            },
+            "@type": "Organization",
+            "name": "EarthChem Library",
+            "@id": "https://www.earthchem.org",
+            "url": "https://www.earthchem.org/library",
+        },
+        "provider": {"@type": "Organization", "name": "EarthChem Library"},
+        "spatialCoverage": {
+            "@type": "Place",
+            "geo": [
+                {"@type": "GeoCoordinates", "latitude": "40.6644474", "longitude": "-77.9056298"},
+                {"@type": "GeoCoordinates", "latitude": "40.6647643", "longitude": "-77.9040381"},
+                {"@type": "GeoCoordinates", "latitude": "40.664841", "longitude": "-77.9072532"},
+                {"@type": "GeoCoordinates", "latitude": "40.6648488", "longitude": "-77.9072458"},
+            ],
+        },
+        "url": "https://doi.org/10.1594/IEDA/100243",
+        "funder": {
+            "@type": "MonetaryGrant",
+            "fundedItem": {"@id": "https://doi.org/10.1594/IEDA/100243"},
+            "funder": [
+                {
+                    "@type": "Organization",
+                    "name": "National Science Foundation",
+                    "url": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=0725019",
+                }
+            ],
+        },
+    }
+
+    scraped_jsonld = format_fields(metadata_json)
+    jsonld = JSONLD(**scraped_jsonld)
+    assert jsonld.provider.name == "EarthChem Library"
+    assert jsonld.context == "https://schema.org/"

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -81,4 +81,4 @@ async def test_earthchem_to_submission(earthchem):
     assert earthchem_submission.repo_type == RepositoryType.EARTHCHEM
     assert earthchem_submission.submitted <= datetime.utcnow()
     assert earthchem_submission.identifier == "947940"
-    assert earthchem_submission.url == get_settings().earthchem_view_url % "947940"
+    assert earthchem_submission.url == get_settings().earthchem_public_view_url % "947940"


### PR DESCRIPTION
A couple of bugs were found for ecl submissions populating discovery.

1. The public view url to scrape the json ld is incorrect.  To address this issue, a new config key was added to settings and is used for building the url used for scraping the jsonld.
2. The parsing of the jsonld fails because the @context key in the scraped jsonld is different than the other repositories.  To address this issue, the context is normalized after scraping to match the structure of the other repositories.