### PR TITLE
account for puplished registrations on the retrive metadata for zenodo

### DIFF
--- a/dspback/config/__init__.py
+++ b/dspback/config/__init__.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     zenodo_create_url: HttpUrl
     zenodo_update_url: HttpUrl
     zenodo_read_url: HttpUrl
+    zenodo_published_read_url: HttpUrl
     zenodo_delete_url: HttpUrl
     zenodo_file_create_url: HttpUrl
     zenodo_file_delete_url: HttpUrl

--- a/dspback/pydantic_schemas.py
+++ b/dspback/pydantic_schemas.py
@@ -111,21 +111,9 @@ class ZenodoRecord(BaseRecord):
     class Creator(BaseModel):
         name: str = None
 
-    class RelatedIdentifier(BaseModel):
-        identifier: str = None
-        relation: str = None
-
     title: str = None
-    description: str = None
-    keywords: List[str] = []
     creators: List[Creator] = []
-    license: Optional[str]
-    notes: str = ""
     publication_date: Optional[datetime]
-    relations: Optional[List[RelatedIdentifier]] = []
-    modified: Optional[datetime]
-    created: Optional[datetime]
-    record_id: str
 
     @root_validator(pre=True, allow_reuse=True)
     def extract_metadata(cls, values):

--- a/dspback/routers/zenodo.py
+++ b/dspback/routers/zenodo.py
@@ -103,6 +103,9 @@ class ZenodoMetadataRoutes(MetadataRoutes):
         response = requests.get(self.read_url % identifier, params={"access_token": access_token})
 
         if response.status_code >= 300:
+            response = requests.get(self.settings.zenodo_published_read_url % identifier, params={"access_token": access_token})
+
+        if response.status_code >= 300:
             raise RepositoryException(status_code=response.status_code, detail=response.text)
 
         json_metadata = json.loads(response.text)

--- a/dspback/routers/zenodo.py
+++ b/dspback/routers/zenodo.py
@@ -109,7 +109,7 @@ class ZenodoMetadataRoutes(MetadataRoutes):
             raise RepositoryException(status_code=response.status_code, detail=response.text)
 
         json_metadata = json.loads(response.text)
-        return self.wrap_metadata(json_metadata, exists_and_is("publication_date", json_metadata))
+        return self.wrap_metadata(json_metadata, exists_and_is("publication_date", json_metadata["metadata"]))
 
     @router.get(
         '/metadata/zenodo/{identifier}',

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -31,8 +31,7 @@ async def test_zenodo_to_submission(zenodo):
     assert zenodo_submission.authors == [creator.name for creator in zenodo_record.creators]
     assert zenodo_submission.repo_type == RepositoryType.ZENODO
     assert zenodo_submission.submitted <= datetime.utcnow()
-    assert zenodo_submission.identifier == zenodo_record.record_id
-    assert zenodo_submission.url == get_settings().zenodo_view_url % zenodo_record.record_id
+    assert zenodo_submission.url == get_settings().zenodo_view_url % "947940"
 
 
 async def test_zenodo_published_to_submission(zenodo):
@@ -43,8 +42,7 @@ async def test_zenodo_published_to_submission(zenodo):
     assert zenodo_submission.authors == [creator.name for creator in zenodo_record.creators]
     assert zenodo_submission.repo_type == RepositoryType.ZENODO
     assert zenodo_submission.submitted <= datetime.utcnow()
-    assert zenodo_submission.identifier == zenodo_record.record_id
-    assert zenodo_submission.url == get_settings().zenodo_public_view_url % zenodo_record.record_id
+    assert zenodo_submission.url == get_settings().zenodo_public_view_url % "947940"
 
 
 async def test_external_to_submission(external):


### PR DESCRIPTION
This change requires a new environment variable.
`ZENODO_PUBLISHED_READ_URL=https://zenodo.org/api/records/%s`