### PR TITLE
[#115] Replace HydroShare default creator data upon resource creation

### DIFF
--- a/dspback/routers/hydroshare.py
+++ b/dspback/routers/hydroshare.py
@@ -104,8 +104,10 @@ class HydroShareMetadataRoutes(MetadataRoutes):
 
         identifier = response.json()["resource_id"]
         # hydroshare doesn't accept all of the metadata on create, it also creates a creator with the user
+        # if our payload provides creators data, it should replace HydroShare's default creator
+        # Note that HydroShare resources must have at least one creator/author at all times.
         new_md = await self._retrieve_metadata_from_repository(request, identifier)
-        metadata.creators = new_md["metadata"]["creators"] + metadata.creators
+        metadata.creators = new_md["metadata"]["creators"] or metadata.creators
         metadata.citation = new_md["metadata"]["citation"]
         json_metadata = await self.update_metadata(request, metadata, identifier)
 

--- a/dspback/schemas/hydroshare/schema.json
+++ b/dspback/schemas/hydroshare/schema.json
@@ -36,6 +36,7 @@
       "description": "A list of Creator objects indicating the entities responsible for creating a resource",
       "default": [],
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/Creator"
       }


### PR DESCRIPTION
Also updates schema to enforce HydroShare's creator requirements (at least one creator for a resource at all times).