### PR TITLE
Zenodo no creator name

### DIFF
--- a/dspback/pydantic_schemas.py
+++ b/dspback/pydantic_schemas.py
@@ -107,6 +107,8 @@ class BaseRecord(BaseModel):
 class ZenodoRecord(BaseRecord):
     class Creator(BaseModel):
         name: str = None
+        affiliation: str = None
+        orcid: str = None
 
     title: str = None
     creators: List[Creator] = []
@@ -118,6 +120,17 @@ class ZenodoRecord(BaseRecord):
         del values['metadata']
         return values
 
+    def submission_authors(self):
+        authors = []
+        for creator in self.creators:
+            if creator.name:
+                authors.append(creator.name)
+            elif creator.orcid:
+                authors.append(creator.orcid)
+            elif creator.affiliation:
+                authors.append(creator.affiliation)
+        return authors
+
     def to_submission(self, identifier) -> Submission:
         settings = get_settings()
         view_url = (
@@ -127,7 +140,7 @@ class ZenodoRecord(BaseRecord):
         )
         return Submission(
             title=self.title,
-            authors=[creator.name for creator in self.creators],
+            authors=self.submission_authors(),
             repo_type=RepositoryType.ZENODO,
             submitted=datetime.utcnow(),
             identifier=identifier,

--- a/dspback/utils/fetch_zenodo_licenses.py
+++ b/dspback/utils/fetch_zenodo_licenses.py
@@ -4,17 +4,20 @@
 
 # Example run `python fetch_zenodo_licenses.py`
 
-import requests
 import json
 
-response = requests.get("https://zenodo.org/api/vocabularies/licenses?page=1&size=10000&sort=title")  # size query param must be an arbitrarily large number
+import requests
+
+response = requests.get(
+    "https://zenodo.org/api/vocabularies/licenses?page=1&size=10000&sort=title"
+)  # size query param must be an arbitrarily large number
 
 vocabulary = response.json()
 licenses = vocabulary["hits"]["hits"]
 
 transformed_licenses = []
 for license in licenses:
-    transformed_license = { "const": license["id"], "title": license["title"]["en"]}
+    transformed_license = {"const": license["id"], "title": license["title"]["en"]}
     transformed_licenses.append(transformed_license)
 
 # Read the existing schema file

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -150,6 +150,12 @@ async def zenodo(change_test_dir):
 
 
 @pytest.fixture
+async def zenodo_no_name(change_test_dir):
+    with open("data/zenodo_no_name.json", "r") as f:
+        return json.loads(f.read())
+
+
+@pytest.fixture
 async def external(change_test_dir):
     with open("data/external.json", "r") as f:
         return json.loads(f.read())

--- a/tests/data/zenodo_no_name.json
+++ b/tests/data/zenodo_no_name.json
@@ -1,0 +1,78 @@
+{
+    "created": "2023-10-27T20:29:17.621668+00:00",
+    "modified": "2023-10-27T20:42:31.215334+00:00",
+    "id": 10048803,
+    "conceptrecid": "10048802",
+    "metadata": {
+      "title": "Test deposit",
+      "publication_date": "2023-10-27",
+      "description": "Test",
+      "access_right": "open",
+      "creators": [
+        {
+          "affiliation": "UWRL",
+          "orcid": "0000-0001-2345-6789"
+        }
+      ],
+      "keywords": [
+        "CZNet",
+        "one",
+        "two",
+        "three"
+      ],
+      "license": "cc-by-4.0",
+      "imprint_publisher": "Zenodo",
+      "communities": [
+        {
+          "identifier": "czdata"
+        }
+      ],
+      "notes": "Funding Agency Name: \nAward Title: \nAward Number: \nFunding Agency URL:",
+      "upload_type": "dataset",
+      "prereserve_doi": {
+        "doi": "10.5281/zenodo.10048803",
+        "recid": 10048803
+      }
+    },
+    "title": "Test deposit",
+    "links": {
+      "self": "https://zenodo.org/api/deposit/depositions/10048803",
+      "html": "https://zenodo.org/deposit/10048803",
+      "badge": "https://zenodo.org/badge/doi/.svg",
+      "files": "https://zenodo.org/api/deposit/depositions/10048803/files",
+      "bucket": "https://zenodo.org/api/files/6cc3f3cd-db72-4fbc-93d9-fa9cd3aaa2d2",
+      "latest_draft": "https://zenodo.org/api/deposit/depositions/10048803",
+      "latest_draft_html": "https://zenodo.org/deposit/10048803",
+      "publish": "https://zenodo.org/api/deposit/depositions/10048803/actions/publish",
+      "edit": "https://zenodo.org/api/deposit/depositions/10048803/actions/edit",
+      "discard": "https://zenodo.org/api/deposit/depositions/10048803/actions/discard",
+      "newversion": "https://zenodo.org/api/deposit/depositions/10048803/actions/newversion",
+      "registerconceptdoi": "https://zenodo.org/api/deposit/depositions/10048803/actions/registerconceptdoi"
+    },
+    "record_id": 10048803,
+    "owner": 367423,
+    "files": [
+      {
+        "id": "29209808-39e8-4658-8a08-3ab68b24ecc0",
+        "filename": "dpback-logs.txt",
+        "filesize": 762473,
+        "checksum": "fee1be2ae7a237646bd4b785b91626c6",
+        "links": {
+          "self": "https://zenodo.org/api/deposit/depositions/10048803/files/29209808-39e8-4658-8a08-3ab68b24ecc0",
+          "download": "https://zenodo.org/api/records/10048803/draft/files/dpback-logs.txt/content"
+        }
+      },
+      {
+        "id": "e573d8f5-3fdd-45b1-8641-d961a3577aab",
+        "filename": "logs.txt",
+        "filesize": 2526,
+        "checksum": "6408a6d5ddea8a01b8c4e4599b92acd4",
+        "links": {
+          "self": "https://zenodo.org/api/deposit/depositions/10048803/files/e573d8f5-3fdd-45b1-8641-d961a3577aab",
+          "download": "https://zenodo.org/api/records/10048803/draft/files/logs.txt/content"
+        }
+      }
+    ],
+    "state": "unsubmitted",
+    "submitted": false
+  }

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -6,7 +6,7 @@ import pytest
 
 from dspback.config import get_settings
 from dspback.pydantic_schemas import EarthChemRecord, ExternalRecord, HydroShareRecord, RepositoryType, ZenodoRecord
-from tests import change_test_dir, earthchem, external, hydroshare, zenodo
+from tests import change_test_dir, earthchem, external, hydroshare, zenodo, zenodo_no_name
 
 
 async def test_hydroshare_to_submission(hydroshare):
@@ -29,6 +29,17 @@ async def test_zenodo_to_submission(zenodo):
 
     assert zenodo_submission.title == zenodo_record.title
     assert zenodo_submission.authors == [creator.name for creator in zenodo_record.creators]
+    assert zenodo_submission.repo_type == RepositoryType.ZENODO
+    assert zenodo_submission.submitted <= datetime.utcnow()
+    assert zenodo_submission.url == get_settings().zenodo_view_url % "947940"
+
+
+async def test_zenodo_to_submission_no_name(zenodo_no_name):
+    zenodo_record = ZenodoRecord(**zenodo_no_name)
+    zenodo_submission = zenodo_record.to_submission("947940")
+
+    assert zenodo_submission.title == zenodo_record.title
+    assert zenodo_submission.authors == ["0000-0001-2345-6789"]
     assert zenodo_submission.repo_type == RepositoryType.ZENODO
     assert zenodo_submission.submitted <= datetime.utcnow()
     assert zenodo_submission.url == get_settings().zenodo_view_url % "947940"


### PR DESCRIPTION
Zenodo no longer returns the creator name in all cases.  This patch looks for orcid or affiliation in the case where the creator name is missing.