### PR TITLE
only allow sortBy parameter values of dateCreated and name

### DIFF
--- a/dspback/routers/discovery.py
+++ b/dspback/routers/discovery.py
@@ -236,9 +236,11 @@ async def base_search(
         must.append({'text': {'path': '@type', 'query': contentType}})
     if clusters:
         stages.append({'$match': {'clusters': {'$all': clusters}}})
-    # Sort needs to happen before pagination
-    if sortBy:
-        stages.append({'$sort': {sortBy: 1}})
+    # Sort needs to happen before pagination, ignore all other values of sortBy
+    if sortBy == "name":
+        stages.append({'$sort': {"name": 1}})
+    if sortBy == "dateCreated":
+        stages.append({'$sort': {"dateCreated": -1}})
     stages.append({'$skip': (pageNumber - 1) * pageSize})
     stages.append(
         {'$limit': pageSize},


### PR DESCRIPTION
When looking into boosting title/name matching scores, I encountered a bug with sorting.  The relevance sortBy does not work and screws up the sorting.  The relevance sortBy isn't needed because the results are already sorted by relevance.

I also updated the dateCreated sort to return the result in descending order.  The results for dateCreated are currently returned in ascending order and includes records that do not have a dateCreated property at the beginning of the results.