### PR TITLE
[#106] Add schema date range validation

### DIFF
--- a/dspback/schemas/external/schema.json
+++ b/dspback/schemas/external/schema.json
@@ -163,6 +163,12 @@
           "format": "date-time",
           "options": {
             "placeholder": "YYYY-MM-DDTHH:MM"
+          },
+          "formatMaximum": {
+            "$data": "1/end"
+          },
+          "errorMessage": {
+            "formatMaximum": "must be lesser than or equal to End date"
           }
         },
         "end": {
@@ -172,6 +178,12 @@
           "format": "date-time",
           "options": {
             "placeholder": "YYYY-MM-DDTHH:MM"
+          },
+          "formatMinimum": {
+            "$data": "1/start"
+          },
+          "errorMessage": {
+            "formatMinimum": "must be greater than or equal to Start date"
           }
         }
       },

--- a/dspback/schemas/hydroshare/schema.json
+++ b/dspback/schemas/hydroshare/schema.json
@@ -616,6 +616,12 @@
           "format": "date-time",
           "options": {
             "placeholder": "YYYY-MM-DDTHH:MM"
+          },
+          "formatMaximum": {
+            "$data": "1/end"
+          },
+          "errorMessage": {
+            "formatMaximum": "must be lesser than or equal to End date"
           }
         },
         "end": {
@@ -625,6 +631,12 @@
           "format": "date-time",
           "options": {
             "placeholder": "YYYY-MM-DDTHH:MM"
+          },
+          "formatMinimum": {
+            "$data": "1/start"
+          },
+          "errorMessage": {
+            "formatMinimum": "must be greater than or equal to Start date"
           }
         }
       },


### PR DESCRIPTION
Fixes https://github.com/cznethub/dsp/issues/106
This schema driven validation now works after the update to Vue 3.