### PR TITLE
Remove response model from other repository endpoints

### DIFF
--- a/dspback/routers/earthchem.py
+++ b/dspback/routers/earthchem.py
@@ -127,7 +127,6 @@ class EarthChemMetadataRoutes(MetadataRoutes):
     @router.get(
         '/metadata/earthchem/{identifier}',
         response_model_exclude_unset=True,
-        response_model=response_model,
         tags=["EarthChem"],
         summary="Get an EarthChem record",
         description="Retrieves the metadata for the EarthChem record.",

--- a/dspback/routers/zenodo.py
+++ b/dspback/routers/zenodo.py
@@ -132,7 +132,6 @@ class ZenodoMetadataRoutes(MetadataRoutes):
     @router.get(
         '/metadata/zenodo/{identifier}',
         response_model_exclude_unset=True,
-        response_model=response_model,
         tags=["Zenodo"],
         summary="Get a Zenodo record",
         description="Retrieves the metadata for the Zenodo record.",


### PR DESCRIPTION
Similar approach to allowing registration of existing resources with incomplete metadata requirements, now for Zenodo and EarthChem.